### PR TITLE
Fixed width of content block

### DIFF
--- a/src/styles/_content.scss
+++ b/src/styles/_content.scss
@@ -6,6 +6,7 @@ main.tiyo-assistant {
     padding: 1em;
     margin-bottom: 1em;
     overflow: hidden;
+    width: 100%;
 }
 
 .tiyo-assistant-module {


### PR DESCRIPTION
This fixes an issue where the content block for newline assistant things (like gradebook) was only taking up half of the screen. My guess is that was because of some change in newline itself.